### PR TITLE
Added missing bower dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "gulp-bump": "^0.1.10",
     "gulp-protractor": "0.0.11",
     "phantomjs": "^1.9.7-15",
-    "protractor": "^1.0.0-rc6"
+    "protractor": "^1.0.0-rc6",
+    "bower": "^1.3.9"
   },
   "scripts": {
     "install": "gulp install",


### PR DESCRIPTION
Added bower dependency into package.json as it is required install new components - or are we expecting to have it installed globally?
