### PR TITLE
Fixed the failing test: npm test first *builds* then *test*

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "install": "gulp install",
     "build": "gulp integrate",
-    "test": "gulp integrate test",
+    "test": "gulp default test",
     "start": "gulp serve"
   }
 }


### PR DESCRIPTION
Root cause: The Gulp integrate task only bundles, it does not build.
