### PR TITLE
Refactor build away from production dependencies. Also fixes #29 and #12

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .*
 *.js
 bower.json
-Dockerfile
 src
 temp
 tests

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
-.git
+.*
+*.js
+bower.json
+Dockerfile
+src
+temp
+tests
 node_modules
-# Project files
-*.sublime-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,3 @@ before_install:
 
 env:
   - NODE_ENV="development"
-  - NODE_ENV="production"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,22 @@
-FROM ubuntu:14.04
+FROM node:0.10-slim
 ENV PORT 8080
 EXPOSE 8080
-ENV PATH ./node_modules/gulp/bin:$PATH
 ENV NODE_ENV production
 
-# Install apps and dependencies
+# Install app dependencies
 # NOTE: These steps depends highly on service in question
-RUN apt-get update
-RUN apt-get install -y nodejs npm git vim ruby1.9.3 ruby-sass ruby-compass
-RUN ln -s /usr/bin/nodejs /usr/bin/node
 
-# Run app as a custom user `app`
+# Switch to non-root user and create a directory for it
 RUN useradd -m -d /app app
-ADD . /app
-WORKDIR /app
+RUN mkdir -p /app
 RUN chown -R app.app /app
 USER app
-ENV HOME /app
-RUN npm install gulp
-RUN ln -s /app/node_modules/gulp/bin/gulp.js /app/node_modules/gulp/bin/gulp
-RUN npm install
-RUN npm run-script build
-# Default command to run service
-CMD npm start
+
+# Install and package production deps; see the extensive 
+# file ignore list at .dockerignore
+WORKDIR /app
+COPY . /app/
+RUN npm install --production
+
+# Use the start script defined in package.json
+CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ USER app
 # Install and package production deps; see the extensive 
 # file ignore list at .dockerignore
 WORKDIR /app
-COPY package.json /app/
-COPY README.md /app/ 
+COPY package.json README.md /app/
 RUN npm install --production
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ USER app
 # Install and package production deps; see the extensive 
 # file ignore list at .dockerignore
 WORKDIR /app
-COPY . /app/
+COPY package.json /app/
+COPY README.md /app/ 
 RUN npm install --production
+COPY . /app
 
 # Use the start script defined in package.json
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -1,26 +1,34 @@
 # Gulp BoBrSASS Boilerplate
 [![Build Status](https://travis-ci.org/SC5/gulp-bobrsass-boilerplate.png?branch=master)](https://travis-ci.org/SC5/gulp-bobrsass-boilerplate.png?branch=master)
 
-In principle BoBrSASS is a modifiable boilerplate that combines some of our best practices:
+BoBrSASS is a modifiable boilerplate combining some of our common tools and
+practices:
 * Gulp for fast builds
+* Browserify for bundling CommonJS modules
+* SASS & Compass stylesheets
 * Runs in background (watching changes), supports live reload
 * Supports source maps for both JavaScript and SASS
-* Browserify (or in future something else) for better web app packaging
 * Spaces instead of tabs
-* SASS & Compass stylesheets
 * Headless protractor acceptance tests
 
 ## Installation
 
 ### Prerequisites
 
-The latest version of BoBrSASS should work with recent versions of Ruby, SASS, Compass, Git and Gulp. Please check the correct versions, maintained in our [Travis configuration](https://github.com/SC5/gulp-bobrsass-boilerplate/blob/master/.travis.yml). If you insist on using an older version of dependencies, earlier versions of the boilerplate may work.
+The latest version of BoBrSASS should work with recent versions of Ruby, SASS,
+Compass and Git. Please check the correct versions, maintained in our
+[Travis configuration](https://github.com/SC5/gulp-bobrsass-boilerplate/blob/master/.travis.yml).
+If you insist on using an older version of dependencies, earlier versions of
+the boilerplate may work.
 
-For system level deps, install [Node.js](http://www.nodejs.org/) 0.10 or later and [Ruby](https://www.ruby-lang.org/en/downloads/) 2.1 or later and [Git](http://git-scm.com/). When using [Git on Windows](http://msysgit.github.io/), remember to enable usage from command prompt.
+For system level deps, install [Node.js](http://www.nodejs.org/) 0.10 or
+later and [Ruby](https://www.ruby-lang.org/en/downloads/) 2.1 or later and
+[Git](http://git-scm.com/). When using
+[Git on Windows](http://msysgit.github.io/), remember to enable usage from
+command prompt.
 
-Install Gulp npm module and Ruby gems for Compass and and SASS as follows:
+Install Ruby gems for Compass and and SASS as follows:
 
-    > npm install -g gulp 
     > gem update --system
     > gem install sass compass
 
@@ -29,34 +37,39 @@ Clone the project and trigger installation of the project npm dependencies by
     > git clone https://github.com/SC5/gulp-bobrsass-boilerplate.git
     > npm install
 
-It actually performs a release build, too (to verify that everything is ok).
-
 ## Building
 
-The current build compiles JS and CSS monoliths for both the debug and release builds. The
-difference in debug builds is that they support source maps and are not minified.
+BoBrSASS uses Gulp internally, but you can use npm scripts to trigger them.
+Build, test etc. tasks utilise npm development dependencies, so one should
+set 'NODE_ENV' to something else than 'production' or install the npm
+dependencies with a '--debug' flag. All the development dependencies are moved
+into devDependencies to avoid slow installs of the actual released software.
 
-To first cleanup your distribution directory and trigger **release** build (with all the tests etc.)
+### Debug and Release builds
 
-    > gulp clean
-    > gulp
+    > npm install --debug       # to force development dependencies
+    > npm run build             # to trigger bower install, build and tests
+    > npm run build -- --debug  # to trigger bower install, debug build and tests
 
-To trigger **debug** build, run gulp with a debug flag
+After this you should have a working, tested build in 'dist' directory.
 
-    > gulp --debug
+### Watching for changes
 
-To keep gulp running and watch for changes, use a combination of the following flags:
+To trigger **debug** build or other features, run the build with a combination
+of the following flags:
 
-    > gulp watch --debug # to disable optimisations, turn on debugging
-    > gulp watch --test  # to run automated tests
-    > gulp watch --nolint # to disable linting
+    > npm run watch -- --debug  # to disable optimisations, turn on debugging
+    > npm run watch -- --test   # to turn on tests when building
+    > npm run watch -- --nolint # to disable linting
 
-To install, build and start everything in production mode (e.g. no devdependencies), do the whole
-shebang as follows:
+The above extra flags '-- [--<flag>]' syntax syntax only works for npm 2.0 or
+later. If you have an earlier version of dislike the syntax, trigger the same
+gulp tasks with your local Gulp installation:
 
-    > npm install --production
-    > npm run-script build
-    > npm start
+    > npm install -g gulp       # to install Gulp CLI locally
+    > gulp install
+    > gulp build --debug
+    > gulp watch --debug --test --nolint
 
 To update your package version, you eventually want to do one of the following:
 
@@ -65,26 +78,34 @@ To update your package version, you eventually want to do one of the following:
     > gulp bump --major
     > gulp bump # defaults to minor
 
-## Running the Service
+## Running
 
 ### Running the Stub Server
-Most likely the normal *gulp serve* task will not suffice, and you want to run your own test
-server, instead. The task below, will default to 'gulp serve' by default until you change it:
 
-    > npm start
-    
+The boilerplate includes a minimal stub [Express](http://expressjs.com/) server
+in 'server/' directory. Its primary purpose is testing the frontend as part of
+the build, but nothing blocks you from expanding it into a full-blown server.
+
+    > npm start                 # to start the server through npm
+    > node server               # to start the server
+
+The server should respond your http requests on local port 8080.
+
 ### Running with Docker
 
-Boilerplate also comes with Docker support. To build and run the container, run:
+Boilerplate also comes with Docker support. To have a minimal Docker image and
+speed up the containerization, the whole app is built before the packaging, and
+only the Node.js production dependencies get packaged. To build and run the
+container, run:
 
-    > docker build -t bobrsass .
-    > docker run -d -P bobrsass
+    > npm run build             # to build the application in production mode
+    > docker build -t bobrsass . # to build the Docker image with name "docker"
+    > docker run -d -P bobrsass # to star the app
 
-To access the service, check the dynamically allocated port (for example: 0.0.0.0:49164->8080/tcp)
-and use it in browser URL
+To access the service, check the dynamically allocated port
+(for example: 0.0.0.0:49164->8080/tcp) and use it in browser URL
 
-    > docker ps
-    # --> http://localhost:49164/
+    > docker ps                 # --> http://localhost:49164/
 
 Localhost works in Linux environment, but if you are using boot2docker, you need to use VM IP
 instead. Check the IP and replace `localhost` with it:
@@ -94,9 +115,9 @@ instead. Check the IP and replace `localhost` with it:
 
 ### Live Reloading the Changes
 
-Live reloading is enabled when running *gulp watch* in another window. Just change any of your
-JavaScript or SASS files to trigger reload. The reload monitors 'dist' directory and pushes the
-changes as needed.
+Live reloading is enabled when running *gulp watch* in another window. Just
+change any of your JavaScript or SASS files to trigger reload. The reload
+monitors 'dist' directory and pushes the changes as needed.
 
 ##  Extending & Hacking
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,27 +1,29 @@
 'use strict';
 
-var path = require('path'),
-    util = require('util'),
-    gulp = require('gulp'),
-    exec = require('exec-wait'),
-    $ = require('gulp-load-plugins')(),
-    runSequence = require('run-sequence'),
-    bowerFiles = require('main-bower-files'),
+var bowerFiles = require('main-bower-files'),
+    browserSync = require('browser-sync'),
+    del = require('del'),
     eventStream = require('event-stream'),
-    pkg = require('./package.json');
+    exec = require('exec-wait'),
+    gulp = require('gulp'),
+    path = require('path'),
+    pkg = require('./package.json'),
+    Promise = require('bluebird'),
+    runSequence = require('run-sequence'),
+    util = require('util'),
+    $ = require('gulp-load-plugins')();
 
 /* Configurations. Note that most of the configuration is stored in
 the task context. These are mainly for repeating configuration items */
 // jscs:disable requireMultipleVarDecl
 var config = {
     version: pkg.version,
+    port: process.env.PORT || pkg.config.port,
+    hostname: process.env.HOSTNAME || pkg.config.hostname,
     debug: Boolean($.util.env.debug) || (process.env.NODE_ENV === 'development'),
     production: Boolean($.util.env.production) || (process.env.NODE_ENV === 'production')
   },
-  port = Number(process.env.PORT || 8080),
-  hostName = process.env.HOSTNAME || 'localhost',
-  host = [hostName, port].join(':'),
-  url = ['http://', host, '/'].join(''),
+  url = ['http://', config.hostname + ':' + config.port, '/'].join(''),
   // Global vars used across the test tasks
   testServerCmdAndArgs = pkg.scripts.start.split(/\s/),
   phantomPath = path.dirname(require.resolve('phantomjs')),
@@ -52,8 +54,6 @@ gulp.task('install', function() {
 });
 
 gulp.task('clean', function(cb) {
-  var del = require('del');
-
   return del([
     'dist',
     // here we use a globbing pattern to match everything inside the `mobile` folder
@@ -72,12 +72,6 @@ gulp.task('bump', function() {
     .pipe($.bump({ type: type }))
     .pipe(gulp.dest('./'));
 });
-
-/* Serve the web site */
-gulp.task('serve', $.serve({
-  root: 'dist',
-  port: port
-}));
 
 gulp.task('jscs', function() {
   return gulp.src(['src/app/**/*.js'])
@@ -173,9 +167,8 @@ gulp.task('integrate', function() {
 });
 
 gulp.task('watch', ['build'], function() {
-  var browserSync = require('browser-sync'),
-    testOnWatch = Boolean(typeof $.util.env.test === 'undefined' ? false : true),
-    lintOnWatch = Boolean(typeof $.util.env.nolint === 'undefined' ? true :  false);
+  var testOnWatch = Boolean(typeof $.util.env.test === 'undefined' ? false : true),
+      lintOnWatch = Boolean(typeof $.util.env.nolint === 'undefined' ? true :  false);
 
   // Watch needs a test server to run; start that.
   return testServer.start()
@@ -199,15 +192,13 @@ gulp.task('watch', ['build'], function() {
       $.util.log('Initialise BrowserSync on port 8081');
       browserSync.init({
         files: 'dist/**/*',
-        proxy: host,
+        proxy: config.hostname,
         port: 8081
       });
     });
 });
 
 gulp.task('test-setup', function() {
-  var Promise = require('bluebird');
-
   return testServer.start()
     .then(ghostDriver.start)
     .then(function() {
@@ -228,7 +219,6 @@ gulp.task('test-setup', function() {
 });
 
 gulp.task('test-run', function() {
-  var Promise = require('bluebird');
   $.util.log('Running protractor');
 
   return new Promise(function(resolve) {
@@ -260,10 +250,6 @@ gulp.task('test', function() {
 // Task combinations
 gulp.task('build', function() {
   return runSequence(['javascript', 'stylesheets', 'assets'], 'integrate');
-});
-
-gulp.task('prepublish', function() {
-  return runSequence('install', 'build', 'test');
 });
 
 gulp.task('default', ['build', 'test']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,8 @@ var config = {
     monitor: { url: url, checkHTTPResponse: false },
     log: $.util.log,
     stopSignal: 'SIGTERM'
-  });
+  }),
+  changeOptions = { hasChanged: $.changed.compareSha1Digest };
 // jscs:enable requireMultipleVarDecl
 
 // Package management
@@ -75,14 +76,12 @@ gulp.task('bump', function() {
 
 gulp.task('jscs', function() {
   return gulp.src(['src/app/**/*.js'])
-    .pipe($.cached('jscs'))
     .pipe($.plumber())
     .pipe($.jscs());
 });
 
 gulp.task('jshint', function() {
   return gulp.src('src/app/**/*.js')
-    .pipe($.cached('jslint'))
     .pipe($.jshint())
     .pipe($.jshint.reporter('default'));
 });
@@ -105,6 +104,7 @@ gulp.task('javascript', function() {
     .pipe($.plumber())
     .pipe($.browserify(browserifyConfig))
     .pipe($.concat(bundleName))
+    .pipe($.changed('dist'), changeOptions)
     .pipe($.if(!config.debug, $.uglify()))
     .pipe(gulp.dest('dist'));
 });
@@ -139,6 +139,7 @@ gulp.task('stylesheets', function() {
       '**/app.css'
     ]))
     .pipe($.concat(bundleName))
+    .pipe($.changed('dist/styles'), changeOptions)
     .pipe($.if(!config.debug, $.csso()))
     .pipe($.if(config.debug,
       $.sourcemaps.write({ sourceRoot: path.join(__dirname, 'src/styles') }))
@@ -150,7 +151,7 @@ gulp.task('stylesheets', function() {
 
 gulp.task('assets', function() {
   return gulp.src('src/assets/**')
-    .pipe($.cached('assets'))
+    .pipe($.changed('dist/assets'), changeOptions)
     .pipe(gulp.dest('dist/assets'));
     // Integration test
 });
@@ -163,7 +164,8 @@ gulp.task('integrate', function() {
   // Check whether to run tests as part of integration
   return target
     .pipe($.inject(source, params))
-    .pipe(gulp.dest('./dist'));
+    .pipe($.changed('dist'), changeOptions)
+    .pipe(gulp.dest('dist'));
 });
 
 gulp.task('watch', ['build'], function() {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "gulp-bobrsass-boilerplate",
+  "description": "BoBrSASS is a modifiable boilerplate",
   "repository": {
     "type": "git",
     "url": "https://github.com/SC5/gulp-bobrsass-boilerplate.git"
@@ -11,46 +12,50 @@
   },
   "private": false,
   "dependencies": {
-    "bluebird": "^2.3.5",
-    "event-stream": "^3.1.7",
-    "exec-wait": "^0.0.3",
-    "phantomjs": "^1.9.10",
-    "gulp": "^3.8.9",
-    "gulp-bower": "^0.0.7",
-    "gulp-browserify": "^0.5.0",
-    "gulp-cached": "^1.0.1",
-    "gulp-compass": "^2.0.1",
-    "gulp-concat": "^2.4.1",
-    "gulp-csslint": "^0.1.5",
-    "gulp-csso": "^0.2.9",
-    "gulp-filter": "^1.0.2",
-    "gulp-if": "^1.2.4",
-    "gulp-inject": "^1.0.2",
-    "gulp-jshint": "^1.8.5",
-    "gulp-load-plugins": "^0.7.0",
-    "gulp-order": "^1.1.1",
-    "gulp-plumber": "^0.6.6",
-    "gulp-protractor": "0.0.11",
-    "gulp-serve": "^0.2.0",
-    "gulp-sourcemaps": "^1.2.7",
-    "gulp-uglify": "^1.0.1",
-    "gulp-util": "^3.0.1",
-    "gulp-watch": "^1.0.7",
-    "main-bower-files": "^2.1.0",
-    "run-sequence": "^1.0.1"
+    "express": "^4.10.7"
   },
   "devDependencies": {
-    "browser-sync": "^1.5.4",
-    "del": "^0.1.3",
-    "git-hooks": "0.0.7",
+    "bluebird": "^2.5.3",
+    "browser-sync": "^1.8.3",
+    "del": "^1.1.1",
+    "event-stream": "^3.2.1",
+    "exec-wait": "^0.0.3",
+    "git-hooks": "0.0.10",
+    "gulp": "^3.8.10",
+    "gulp-bower": "^0.0.7",
+    "gulp-browserify": "^0.5.0",
     "gulp-bump": "^0.1.11",
-    "gulp-jscs": "^1.3.1",
+    "gulp-cached": "^1.0.1",
+    "gulp-compass": "^2.0.1",
+    "gulp-concat": "^2.4.3",
+    "gulp-csslint": "^0.1.5",
+    "gulp-csso": "^0.2.9",
+    "gulp-filter": "^2.0.0",
+    "gulp-if": "^1.2.4",
+    "gulp-inject": "^1.1.1",
+    "gulp-jscs": "^1.4.0",
+    "gulp-jshint": "^1.8.5",
+    "gulp-load-plugins": "^0.8.0",
+    "gulp-order": "^1.1.1",
     "gulp-plumber": "^0.6.6",
-    "jscs": "^1.6.2"
+    "gulp-protractor": "0.0.12",
+    "gulp-sourcemaps": "^1.3.0",
+    "gulp-uglify": "^1.0.2",
+    "gulp-util": "^3.0.1",
+    "gulp-watch": "^3.0.0",
+    "jscs": "^1.9.0",
+    "main-bower-files": "^2.1.0",
+    "phantomjs": "^1.9.13",
+    "run-sequence": "^1.0.1"
+  },
+  "config": {
+    "port": 8080,
+    "hostname": "localhost"
   },
   "scripts": {
-    "prepublish": "gulp prepublish",
-    "test": "gulp build test",
-    "start": "gulp serve"
+    "build": "gulp build",
+    "test": "gulp test",
+    "watch": "gulp watch",
+    "start": "node server"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp-bower": "^0.0.7",
     "gulp-browserify": "^0.5.0",
     "gulp-bump": "^0.1.11",
-    "gulp-cached": "^1.0.1",
+    "gulp-changed": "^1.1.0",
     "gulp-compass": "^2.0.1",
     "gulp-concat": "^2.4.3",
     "gulp-csslint": "^0.1.5",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,13 @@
+var express = require('express'),
+    app = express(),
+    pkg = require('../package.json'),
+    config = {
+      version: pkg.version,
+      port: process.env.PORT || pkg.config.port,
+      hostname: process.env.HOSTNAME || pkg.config.hostname
+    };
+
+app.use(express.static(__dirname + '/../dist'));
+app.listen(config.port);
+
+console.log('Stub server running on port ' + config.port);


### PR DESCRIPTION
This is a rather major refactoring of the build process - all build (and hence all development dependencies) out from dependencies to devDependencies. This also enables faster Docker builds (only copy the production deps).

This also necessitates bundling a tiny express file server (into production).

If this is fine & dandy, I'll make another PR where the dist files are watched for changes and subsequent docker builds won't always copy everything there.