### PR TITLE
Use Bundler to handle gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem "sass"
+gem "compass"

--- a/README.md
+++ b/README.md
@@ -27,16 +27,15 @@ later and [Ruby](https://www.ruby-lang.org/en/downloads/) 2.1 or later and
 [Git on Windows](http://msysgit.github.io/), remember to enable usage from
 command prompt.
 
-Install Ruby gems for Compass and and SASS as follows:
-
-    > gem update --system
-    > gem install sass compass
-
 Clone the project and trigger installation of the project dependencies by
 
     > git clone https://github.com/SC5/gulp-bobrsass-boilerplate.git
     > npm install
     > npm run deps
+
+If `deps` fails on Ruby gem dependencies, try updating rubygems as follows:
+
+    > gem update --system
 
 ## Building
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,8 @@ gulp.task('stylesheets', function() {
     .pipe($.compass({
       project: __dirname,
       sass: 'src/styles',
-      css: 'temp/styles'
+      css: 'temp/styles',
+      bundle_exec: true
     }))
     .pipe($.concat('app.css'));
   //jscs:enable requireMultipleVarDecl

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "build": "gulp build",
-    "deps": "gulp install",
+    "deps": "./system-deps.sh && gulp install",
     "test": "gulp test",
     "watch": "gulp watch",
     "start": "node server"

--- a/system-deps.sh
+++ b/system-deps.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if ruby --version; then
+    echo 'Ruby found.'
+else
+    echo 'DEPENDENCY MISSING!'
+    echo 'Install Ruby <https://www.ruby-lang.org/>'
+    return 1;
+fi
+
+if bundle --version; then
+    echo 'Bundler found, running `bundle install`.'
+    echo 'If this fails, try to update rubygems: `gem update --system`.'
+    bundle install
+else
+    echo 'DEPENDENCY MISSING!'
+    echo 'Install <http://bundler.io/>, usually `gem install bundler`.'
+    return 1;
+fi


### PR DESCRIPTION
Use Bundler to manage gem dependencies, which allows convenient deps locking or version limitations in case needed. Also scriptify system deps check to reduce "cold boot" from five to three commands (in case Ruby is already available) and inform user about missing deps.