### PR TITLE
Fixed system-deps errors, gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,22 @@
-temp
-dist
-node_modules
-src/components
-.sass-cache
-phantomjs.log
+# Application build artifacts
+/dist
+/temp
+
+# Dependencies and tools
+/node_modules
+/src/components
+
+# OS artifacts
+.DS_Store
+
+# Tools
+/Gemfile.lock
+/npm-debug.log
+/phantomjs.log
+/.sass-cache
+
+# Editors
+.project
+.settings
 *.sublime-*
-npm-debug.log
+*.swp

--- a/system-deps.sh
+++ b/system-deps.sh
@@ -1,19 +1,25 @@
 #!/bin/sh
 
-if ruby --version; then
+echo 'Checking Ruby:'
+
+if ruby --version 2>/dev/null; then
     echo 'Ruby found.'
+    echo
 else
     echo 'DEPENDENCY MISSING!'
     echo 'Install Ruby <https://www.ruby-lang.org/>'
-    return 1;
+    exit 1
 fi
 
-if bundle --version; then
+echo 'Checking Bundler:'
+
+if bundle --version 2>/dev/null; then
     echo 'Bundler found, running `bundle install`.'
     echo 'If this fails, try to update rubygems: `gem update --system`.'
+    echo
     bundle install
 else
     echo 'DEPENDENCY MISSING!'
     echo 'Install <http://bundler.io/>, usually `gem install bundler`.'
-    return 1;
+    exit 2
 fi


### PR DESCRIPTION
- use `exit` instead of `return` in `system-deps`
- cleaner messaging from `system-deps`
- added `Gemfile.lock` generated by builder to git ignores; other common additions
- added structure to git ignores