### PR TITLE
Install gems to `vendor/bundle` to avoid permission issues in CI

### DIFF
--- a/system-deps.sh
+++ b/system-deps.sh
@@ -9,9 +9,9 @@ else
 fi
 
 if bundle --version; then
-    echo 'Bundler found, running `bundle install`.'
+    echo 'Bundler found, running `bundle install --path vendor/bundle`.'
     echo 'If this fails, try to update rubygems: `gem update --system`.'
-    bundle install
+    bundle install --path vendor/bundle
 else
     echo 'DEPENDENCY MISSING!'
     echo 'Install <http://bundler.io/>, usually `gem install bundler`.'


### PR DESCRIPTION
Be explicit to install all gems under the app source tree to avoid permission issues in CI.